### PR TITLE
Fixes for menu_link tranlsation settings

### DIFF
--- a/sites/all/modules/custom/mlh_translation_ui/README.md
+++ b/sites/all/modules/custom/mlh_translation_ui/README.md
@@ -1,0 +1,27 @@
+# mlh_translation_ui
+
+This module is intended to prevent users from choosing the option to translate menu_link items within the node edit pages.
+
+During install it will also clean out any old nodes that were using this setting, so that the translation box is never checked on the node level.
+
+## Post-install follow-up task
+
+After this module has been installed it will be necessary to visit the following pages to get the fixed menu_links into the translation interface:
+
+ - Go to /admin/config/regional/translate/i18n_string
+ - Check the "menu" box
+ - Submit the form and wait for it to complete
+
+## Testing the results
+
+Before installing the module and running the string update:
+
+ - Go to the "sources" menu in the admin toolbar and choose "menu link"
+ - Search for "Help for MLH website Admins"
+ - it will not be showing if you have not installed AND done the follow-up task above.
+
+ After installing the module and running the above follow-up task:
+
+ - Go to "sources" menu and select "menu link"
+ - Search for "Help for MLH website Admins"
+ - This time it should show one entry available for translation.

--- a/sites/all/modules/custom/mlh_translation_ui/mlh_translation_ui.info
+++ b/sites/all/modules/custom/mlh_translation_ui/mlh_translation_ui.info
@@ -1,0 +1,5 @@
+name = MLH Translation UI
+core = 7.x
+version =1.0
+package = Custom
+description = Overrides node edit form to prevent selection of problematic options. During install it will delete any i18n translation sets and update menu_links to be neutral.

--- a/sites/all/modules/custom/mlh_translation_ui/mlh_translation_ui.install
+++ b/sites/all/modules/custom/mlh_translation_ui/mlh_translation_ui.install
@@ -1,0 +1,15 @@
+<?php
+
+function mlh_translation_ui_install() {
+  db_update('system')
+    ->fields(array('weight' => 20))
+    ->condition('name', 'mlh_translation_ui', '=')
+    ->execute();
+
+  db_update('menu_links')
+    ->fields(array('i18n_tsid' => 0, 'language' => 'und'))
+    ->execute();
+
+  db_delete('i18n_translation_set')
+    ->execute();
+}

--- a/sites/all/modules/custom/mlh_translation_ui/mlh_translation_ui.module
+++ b/sites/all/modules/custom/mlh_translation_ui/mlh_translation_ui.module
@@ -1,0 +1,10 @@
+<?php
+
+function mlh_translation_ui_form_alter(&$form, &$form_state, $form_id) {
+  if (isset($form['type']) && $form['type']['#value'] . '_node_form' == $form_id) {
+    $form['menu']['link']['tset']['#title'] = "This site uses menu items placed into language-specific menus so this option has been disabled.";
+    $form['menu']['link']['tset']['#description'] = "";
+    $form['menu']['link']['tset']['#disabled'] = TRUE;
+    $form['menu']['link']['tset']['#default_value'] = FALSE;
+  }
+}


### PR DESCRIPTION
There is an included README.md in the new custom mlh_translation_ui module that will describe the process. It is important to do 2 things to correct the current settings:

1. Enable this new module, mlh_translation_ui
2. Go to the /admin/config/regional/translate/i18n_string page and check "menu" and submit the form.

After doing this the string index will be updated and you will be able to translate the menu links again.

Please see the README.md for additional details and example node to use as a verification.

Be aware this makes database changes so you should run this on a test database first. If the module installs cleanly everything should be fine.